### PR TITLE
fix(App) Fix misspelling of state property

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -89,7 +89,7 @@ class App extends Component {
   };
 
   gameStateSetterFactory = gameState => state => ({
-    gameState: stateReducer({ ...state.gameStatem, ...gameState }),
+    gameState: stateReducer({ ...state.gameState, ...gameState }),
   });
 
   setGameState = gameState => {


### PR DESCRIPTION
Fixing spelling error: `...state.gameStatem` --> `...state.gameState`